### PR TITLE
Corrected puppet manifests, module path in ubuntu-11.10-32bit/Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.vagrant
 *.box
 iso*
+*~

--- a/ubuntu-11.10-32bit/Vagrantfile
+++ b/ubuntu-11.10-32bit/Vagrantfile
@@ -30,8 +30,8 @@ Vagrant::Config.run do |config|
         config.vm.network(:hostonly, "33.33.33.12", :adapter => 2, :auto_config => false)
         config.vm.network(:hostonly, "33.33.34.12", :adapter => 3, :auto_config => false)
         config.vm.provision :puppet do |puppet|
-            puppet.manifests_path   = "modules/ganeti_tutorial/nodes"
-            puppet.module_path      = "modules"
+            puppet.manifests_path   = "../modules/ganeti_tutorial/nodes"
+            puppet.module_path      = "../modules"
             puppet.manifest_file    = "node2.pp"
         end
     end
@@ -48,8 +48,8 @@ Vagrant::Config.run do |config|
         config.vm.network(:hostonly, "33.33.33.13", :adapter => 2, :auto_config => false)
         config.vm.network(:hostonly, "33.33.34.13", :adapter => 3, :auto_config => false)
         config.vm.provision :puppet do |puppet|
-            puppet.manifests_path   = "modules/ganeti_tutorial/nodes"
-            puppet.module_path      = "modules"
+            puppet.manifests_path   = "../modules/ganeti_tutorial/nodes"
+            puppet.module_path      = "../modules"
             puppet.manifest_file    = "node3.pp"
         end
     end


### PR DESCRIPTION
- Corrected puppet manifests, module path in ubuntu-11.10-32bit/Vagrantfile
  Refs Issue #4
- Added an extra gedit cache files filter to .gitignore.
